### PR TITLE
Python 3+ fix: dict.has_key -> in

### DIFF
--- a/stochpy/modules/PyscesMiniModel.py
+++ b/stochpy/modules/PyscesMiniModel.py
@@ -1372,7 +1372,7 @@ class IntegrationStochasticDataObj(object):
         """
         output = self.time
 
-        if kwargs.has_key('lbls'):
+        if 'lbls' in kwargs:
             lbls = kwargs['lbls']
         else:
             lbls = False


### PR DESCRIPTION
Simple change, I want to use this as a submodule in a package I am writing. My package is python 3.6+, and I don't want to include stochpy's entire source in my package.