### PR TITLE
Fixes chdir temporary change when building the lexer

### DIFF
--- a/stochpy/core2/InfixParser.py
+++ b/stochpy/core2/InfixParser.py
@@ -166,6 +166,7 @@ class MyInfixLexer:
     # Build the lexer
     def buildlexer(self,**kwargs):
         # try and find a temporary workspace
+        currentDirectory = os.getcwd()
         if 'TMP' in os.environ:
             tempDir = os.environ['TMP']
         elif 'TEMP' in os.environ:
@@ -174,6 +175,7 @@ class MyInfixLexer:
             tempDir = os.getcwd()
         os.chdir(tempDir)
         self.lexer = lex.lex(object=self, **kwargs)
+        os.chdir(currentDirectory)
 
     # Test it output
     def testlexer(self,data):


### PR DESCRIPTION
Our team was using this package for a project. We noticed that the current working directory was changed on Windows platforms only.

We pinpointed the problem to be here. When the directory is changed for building the lexer, it is never changed back to the original cwd. The result is a break of the relative paths.

The fix we provided was to store the current working directory as we enter the function, and revert it back once the lexer has been setup.