### PR TITLE
Modernization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = ["setuptools>=42", "wheel", "numpy>=1.21.6"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "StochPy"
+version = "2.4"
+description = "StochPy (Stochastic modeling in Python) provides several stochastic simulation algorithms to simulate (bio)chemical systems of reactions in a stochastic manner."
+readme = "README.md"
+authors = [
+    {name = "T.R. Maarleveld", email = "tmd200@users.sourceforge.net"},
+]
+maintainers = [
+    {name = "Brett Olivier", email = "tmd200@users.sourceforge.net"},
+]
+license = {text = "BSD License"}
+requires-python = ">=3.7"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Development Status :: 6 - Mature",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
+keywords = ["Bioinformatics", "Computational Systems Biology", "Modeling", "Simulation", "Stochastic Simulation Algorithms", "Stochastic"]
+dependencies = [
+    "numpy>=1.21.6",
+    "scipy",
+    "matplotlib",
+    "lxml",
+    "mpmath",
+    "ipython",
+]
+
+[project.urls]
+"Homepage" = "http://stochpy.sourceforge.net"
+"Download" = "https://github.com/SystemsBioinformatics/stochpy"
+"Bug Tracker" = "https://github.com/SystemsBioinformatics/stochpy/issues"
+
+[tool.setuptools]
+package-dir = {"" = "."}
+packages = [
+    "stochpy",
+    "stochpy.lib",
+    "stochpy.modules",
+    "stochpy.pscmodels",
+    "stochpy.implementations",
+    "stochpy.core2",
+    "stochpy.tools"
+]
+include-package-data = true

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 from __future__ import division, print_function, absolute_import
-
 __doc__ = "StochPy (Stochastic modeling in Python) provides several stochastic simulation algorithms to simulate (bio)chemical systems of reactions in a stochastic manner."
 __version__ = "2.4"
-
 import os
+import sys
 
 try:
     import setuptools
@@ -12,61 +11,67 @@ try:
 except:
     print('Using distutils')
 
-
 try:
-    from numpy.distutils.core import setup
+    import numpy
 except Exception as ex:
     print(ex)
     print("StochPy requires NumPy\n")
     print("See http://numpy.scipy.org/ for more information about NumPy")
-    os.sys.exit(-1)
+    sys.exit(-1)
 
-local_path = os.path.dirname(os.path.abspath(os.sys.argv[0]))		# Get the dir of setup.py
+local_path = os.path.dirname(os.path.abspath(sys.argv[0]))  # Get the dir of setup.py
 os.chdir(local_path)
 
 mydata_files = []
 modfold = os.path.join(local_path, 'stochpy', 'pscmodels')
 mods = os.listdir(modfold)
-
-mypackages = ['stochpy','stochpy.lib','stochpy.modules','stochpy.pscmodels','stochpy.implementations','stochpy.core2','stochpy.tools']		# My subpackage list
+mypackages = ['stochpy','stochpy.lib','stochpy.modules','stochpy.pscmodels','stochpy.implementations','stochpy.core2','stochpy.tools']  # My subpackage list
 mymodules = []
 
-setup(name="StochPy",
-    version = __version__,
-    description = __doc__,
-    long_description = """
+setup(
+    name="StochPy",
+    version=__version__,
+    description=__doc__,
+    long_description="""
     Welcome to the installation of StochPy {0:s}!
-
     StochPy (Stochastic modeling in Python) is a flexible software tool for stochastic simulation in cell biology. It provides various stochastic simulation algorithms, SBML support, analyses of the probability distributions of molecule copy numbers and event waiting times, analyses of stochastic time series, and a range of additional statistical functions and plotting facilities for stochastic simulations.
     """.format(__version__),
-    author = "T.R. Maarleveld",
-    author_email = "tmd200@users.sourceforge.net",
-    maintainer = "Brett Olivier",
-    maintainer_email = "tmd200@users.sourceforge.net",
-    url = "http://stochpy.sourceforge.net",
-    download_url = "https://github.com/SystemsBioinformatics/stochpy",
-    license = " BSD License ",
-    keywords = " Bioinformatics, Computational Systems Biology, Bioinformatics, Modeling, Simulation, Stochastic Simulation Algorithms, Stochastic",
-    zip_safe = False,
-    requires = ['NumPy'],
-    platforms = ["Windows", "Linux","Mac OS-X"],#, "Solaris", "", "Unix"],
-    classifiers = [
-    'Development Status :: 5 - Production/Stable',
-    'Development Status :: 6 - Mature',
-    'Environment :: Console',
-    'Intended Audience :: End Users/Desktop',
-    'Intended Audience :: Science/Research',
-    'License :: OSI Approved :: BSD License',
-    'Natural Language :: English',
-    'Operating System :: OS Independent',
-    'Programming Language :: Python :: 2.6',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
-    'Topic :: Scientific/Engineering :: Bio-Informatics'],
-    packages = mypackages,
-    data_files = mydata_files
-    )
+    author="T.R. Maarleveld",
+    author_email="tmd200@users.sourceforge.net",
+    maintainer="Brett Olivier",
+    maintainer_email="tmd200@users.sourceforge.net",
+    url="http://stochpy.sourceforge.net",
+    download_url="https://github.com/SystemsBioinformatics/stochpy",
+    license="BSD License",
+    keywords="Bioinformatics, Computational Systems Biology, Bioinformatics, Modeling, Simulation, Stochastic Simulation Algorithms, Stochastic",
+    zip_safe=False,
+    python_requires='>=3.6',
+    install_requires=[
+        'numpy>=1.21.6',
+        'scipy',
+        'matplotlib',
+        'lxml',
+        'mpmath',
+        'ipython',
+    ],
+    platforms=["Windows", "Linux", "Mac OS-X"],  # "Solaris", "", "Unix"],
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Development Status :: 6 - Mature',
+        'Environment :: Console',
+        'Intended Audience :: End Users/Desktop',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: BSD License',
+        'Natural Language :: English',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Topic :: Scientific/Engineering :: Bio-Informatics'
+    ],
+    packages=mypackages,
+    data_files=mydata_files
+)

--- a/stochpy/core2/InfixParser.py
+++ b/stochpy/core2/InfixParser.py
@@ -17,7 +17,7 @@ Brett G. Olivier
 from __future__ import print_function
 from __future__ import absolute_import
 
-import os,math,imp
+import os,math,importlib
 
 from .version import __version__
 from . import  lex
@@ -444,5 +444,5 @@ class MyInfixParser(MyInfixLexer):
         if self._runCount > self._runCountmax:
             self._runCount == 0
             # we're back !!!
-            imp.reload(lex)
-            imp.reload(yacc)
+            importlib.reload(lex)
+            importlib.reload(yacc)

--- a/stochpy/modules/PyscesMiniModel.py
+++ b/stochpy/modules/PyscesMiniModel.py
@@ -29,7 +29,7 @@ InfixParser.buildlexer()
 InfixParser.buildparser(debug=0, debugfile='infix.dbg', tabmodule='infix_tabmodule',outputdir = output_dir) # 28/08/2014. outputdir added
 InfixParser.setNameStr('self.', '')
 
-mach_spec = np.MachAr()
+mach_eps = np.finfo(float).eps
 pscParser = PyscesParse.PySCeSParser(debug=0)
 
 class NewCoreBase(object):
@@ -1115,7 +1115,7 @@ class IntegrationStochasticDataObj(object):
                 variance = sum((self.waiting_times_means[i]- waiting_times_r)**2)/len(waiting_times_r)
                 self.waiting_times_standard_deviations.append(variance**0.5)
             else:
-                self.waiting_times_standard_deviations.append(np.NAN)
+                self.waiting_times_standard_deviations.append(np.nan)
 
 
     def setWaitingtimes(self, waiting_times, lbls=None):

--- a/stochpy/modules/PyscesParse.py
+++ b/stochpy/modules/PyscesParse.py
@@ -21,7 +21,7 @@ from __future__ import division, print_function, absolute_import
 
 from stochpy import model_dir, output_dir
 
-import os,copy,sys,imp
+import os,copy,sys,importlib
 from ..lib import lex
 from ..lib import yacc
 
@@ -1230,8 +1230,8 @@ class PySCeSParser:
         self.ModelUsesNumpyFuncs = False
 
         # 4 hrs of debugging and these two lines solve the problem .... I'm out of here!
-        imp.reload(lex)
-        imp.reload(yacc)
+        importlib.reload(lex)
+        importlib.reload(yacc)
         # fixes the obscure reload <--> garbage collection reference overload bug ... who said scripted lang's were
         # easy to use :-) - brett 20040122
 

--- a/stochpy/modules/StochPyCellDivision.py
+++ b/stochpy/modules/StochPyCellDivision.py
@@ -1003,7 +1003,7 @@ class CellDivision(ExtrapolateExtant,PlottingFunctions):
         t_division = self.StochSim.settings.endtime
         self._output_after_division.insert(0, t_division )
         if not self.StochSim._IsTauleaping:
-            self._output_after_division.append(np.NAN)      # no reaction occurs at cell division
+            self._output_after_division.append(np.nan)      # no reaction occurs at cell division
 
         if self.StochSim.SSA._IsSpeciesSelection:
             self._species_at_birth.append([self._output_after_division[i] for i in self.StochSim.SSA.sim_output_indices[1:-1]])

--- a/stochpy/modules/StochPyUtils.py
+++ b/stochpy/modules/StochPyUtils.py
@@ -58,7 +58,7 @@ def doSequentialSim(smod,n_generations,cell_division_times):
         ### replace last time point with species amounts after division ###
         species_after_division = copy.deepcopy(list(smod.settings.X_matrix))
         species_after_division.insert(0,cell_division_times[0:i].sum()) # add time of cell division
-        species_after_division.append(np.NAN) # no specific reaction occured at cell division
+        species_after_division.append(np.nan) # no specific reaction occured at cell division
         smod.SSA.sim_output[-1] = copy.deepcopy(species_after_division) 
  
         ### Set settings for new simulation and simulate the next generation ### 


### PR DESCRIPTION
This PR updates StochPy to work with modern Python (3.10+) and NumPy (2.x) versions by addressing several deprecation issues:
 Changes:

Replaced deprecated numpy.distutils with standard setuptools
Added pyproject.toml for modern Python packaging (PEP 621)
Updated dependency specifications to work with newer packages

Replaced imp module (removed in Python 3.10) with importlib
Updated reload functionality in PyscesParse.py and InfixParser.py

Replaced deprecated np.NAN with np.nan in multiple files
Replaced deprecated np.MachAr() with np.finfo(float).eps

All changes have been tested with Python 3.13.2 and NumPy 2.2.3. A comprehensive test suite confirmed that StochPy's core functionality continues to work properly with these modern packages.